### PR TITLE
fix(db): Use upsert to save scores

### DIFF
--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -253,11 +253,11 @@ const dbService = {
   async addScore(data: { alunoId: string; questaoId: string; resposta: Alternativa }): Promise<Score> {
     const { data: inserted, error } = await supabase
       .from('scores')
-      .insert({
+      .upsert({
         aluno_id: data.alunoId,
         questao_id: data.questaoId,
         resposta: data.resposta,
-      })
+      }, { onConflict: 'aluno_id,questao_id' })
       .select()
       .single()
     if (error) throw error


### PR DESCRIPTION
Changed the `addScore` function in `dbService.ts` to use `upsert` instead of `insert`.

This prevents errors when a user submits answers for the same test multiple times, ensuring that the latest submission updates the record instead of causing a duplicate key error. This makes the data saving process more robust and reliable.